### PR TITLE
fix: install kernel-modules-core if available

### DIFF
--- a/scripts/lib/builder/kernel.sh
+++ b/scripts/lib/builder/kernel.sh
@@ -113,10 +113,22 @@ kernel::build::install() {
 	local kernel
 	kernel="$(kernel::from_buildid "$buildid")" || return
 
-	dnf install -y \
-		"${tmpdir}/kernel-core-${kernel}.rpm" \
-		"${tmpdir}/kernel-devel-${kernel}.rpm" \
-		|| return
+	local -a rpms_candidates=(
+		"${tmpdir}/kernel-core-${kernel}.rpm"
+		"${tmpdir}/kernel-modules-${kernel}.rpm"
+		"${tmpdir}/kernel-modules-core-${kernel}.rpm"
+		"${tmpdir}/kernel-devel-${kernel}.rpm"
+	)
+
+	local -a rpms
+	local rpm
+	for rpm in "${rpms_candidates[@]}"; do
+		if [[ -f "$rpm" ]]; then
+			rpms+=( "$rpm" )
+		fi
+	done
+
+	dnf install -y "${rpms[@]}" || return
 
 	rm -rf "${tmpdir}"
 }


### PR DESCRIPTION
kernel-core-6.2.0-0.rc6.44.fc38 fails to install without it.